### PR TITLE
fix typo in auth error message

### DIFF
--- a/pkg/git/provider.go
+++ b/pkg/git/provider.go
@@ -44,7 +44,7 @@ type (
 var (
 	ErrProviderNotSupported = errors.New("git provider not supported")
 	ErrAuthenticationFailed = func(err error) error {
-		return fmt.Errorf("authentication failed, make sure credetials are correct: %w", err)
+		return fmt.Errorf("authentication failed, make sure credentials are correct: %w", err)
 	}
 )
 


### PR DESCRIPTION
This PR fixes a typo in an error message about incorrect credentials