### PR TITLE
failed to build bootstrap manifests with namespaced flag

### DIFF
--- a/hack/build.sh
+++ b/hack/build.sh
@@ -14,5 +14,5 @@ ${PACKR_CMD} build -ldflags=" \
     -X 'github.com/argoproj/argocd-autopilot/pkg/store.buildDate=${BUILD_DATE}' \
     -X 'github.com/argoproj/argocd-autopilot/pkg/store.gitCommit=${GIT_COMMIT}' \
     -X 'github.com/argoproj/argocd-autopilot/pkg/store.installationManifestsURL=${INSTALLATION_MANIFESTS_URL}' \
-    -X 'github.com/argoproj/argocd-autopilot/pkg/store.InstallationManifestsNamespacedURL=${INSTALLATION_MANIFESTS_NAMESPACED_URL}'" \
+    -X 'github.com/argoproj/argocd-autopilot/pkg/store.installationManifestsNamespacedURL=${INSTALLATION_MANIFESTS_NAMESPACED_URL}'" \
     -v -o ${OUT_FILE} ${MAIN}


### PR DESCRIPTION
```bash
➜  ~ argocd-autopilot version
v0.1.6
```

Hi,

when i try to run `argocd-autopilot`with the flag namespaced

```bash
➜  ~ argocd-autopilot repo bootstrap --namespaced  --revision initial
```

i get following error message

```bash
FATAL failed to build bootstrap manifests: accumulating resources: accumulation err='accumulating resources from 'manifests/namespace-install': evalsymlink failure on '/private/var/folders/xs/0_2_44gs0jd0l6zq30hgrnsr0000gp/T/auto-pilot974537526/manifests/namespace-install' : lstat /private/var/folders/xs/0_2_44gs0jd0l6zq30hgrnsr0000gp/T/auto-pilot974537526/manifests: no such file or directory': evalsymlink failure on '/private/var/folders/xs/0_2_44gs0jd0l6zq30hgrnsr0000gp/T/auto-pilot974537526/manifests/namespace-install' : lstat /private/var/folders/xs/0_2_44gs0jd0l6zq30hgrnsr0000gp/T/auto-pilot974537526/manifests: no such file or directory
```

After some digging through the code, i found a type in the variable in the `build.sh`

`-X 'github.com/argoproj/argocd-autopilot/pkg/store.InstallationManifestsNamespacedURL=${INSTALLATION_MANIFESTS_NAMESPACED_URL}'" \`

This is the fix for it.

Test:

```bash
➜  argocd-autopilot git:(main) make clean    
➜  argocd-autopilot git:(main) ✗ make cli-local
Building "dist/argocd-autopilot-darwin-amd64" with flags: "GOOS=darwin GOARCH=amd64 CGO_ENABLED=0" starting at: "./cmd"
building box ../../assets
packing file README.md
packed file README.md
packing file badge.svg
packed file badge.svg
packing file builtin-policy.csv
packed file builtin-policy.csv
packing file model.conf
packed file model.conf
packing file swagger.json
packed file swagger.json
built box ../../assets with ["README.md" "badge.svg" "builtin-policy.csv" "model.conf" "swagger.json"]
➜  argocd-autopilot git:(main) ✗ cd dist 
➜  dist git:(main) ✗ ./argocd-autopilot-darwin-amd64 repo bootstrap --namespaced  --revision initial 
INFO cloning repo: https://github.com/dirien/argocd-autopilot.git 
Enumerating objects: 12, done.
Counting objects: 100% (12/12), done.
Compressing objects: 100% (9/9), done.
Total 12 (delta 1), reused 12 (delta 1), pack-reused 0
INFO using revision: "initial", installation path: "" 
```
