### PR TITLE
Rename the binary archive from just .gz zo .tar.gz. 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,13 +69,13 @@ $(OUT_DIR)/$(CLI_NAME)-linux-arm64: GO_FLAGS='GOOS=linux GOARCH=arm64 CGO_ENABLE
 $(OUT_DIR)/$(CLI_NAME)-linux-ppc64le: GO_FLAGS='GOOS=linux GOARCH=ppc64le CGO_ENABLED=0'
 $(OUT_DIR)/$(CLI_NAME)-linux-s390x: GO_FLAGS='GOOS=linux GOARCH=s390x CGO_ENABLED=0'
 
-$(OUT_DIR)/$(CLI_NAME)-%.gz:
+$(OUT_DIR)/$(CLI_NAME)-%.tar.gz:
 	@make $(OUT_DIR)/$(CLI_NAME)-$*
-	cd $(OUT_DIR) && tar -czvf $(CLI_NAME)-$*.gz $(CLI_NAME)-$* && cd ..
+	cd $(OUT_DIR) && tar -czvf $(CLI_NAME)-$*.tar.gz $(CLI_NAME)-$* && cd ..
 
 $(OUT_DIR)/$(CLI_NAME)-%.sha256:
-	@make $(OUT_DIR)/$(CLI_NAME)-$*.gz
-	openssl dgst -sha256 "$(OUT_DIR)/$(CLI_NAME)-$*.gz" | awk '{ print $$2 }' > "$(OUT_DIR)/$(CLI_NAME)-$*".sha256
+	@make $(OUT_DIR)/$(CLI_NAME)-$*.tar.gz
+	openssl dgst -sha256 "$(OUT_DIR)/$(CLI_NAME)-$*.tar.gz" | awk '{ print $$2 }' > "$(OUT_DIR)/$(CLI_NAME)-$*".sha256
 
 $(OUT_DIR)/$(CLI_NAME)-%: $(CLI_SRCS) $(GOBIN)/packr
 	@GO_FLAGS=$(GO_FLAGS) \

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ The Argo-CD Autopilot is a tool which offers an opinionated way of installing Ar
 VERSION=$(curl --silent "https://api.github.com/repos/argoproj-labs/argocd-autopilot/releases/latest" | grep '"tag_name"' | sed -E 's/.*"([^"]+)".*/\1/')
 
 # download and extract the binary
-curl -L --output - https://github.com/argoproj-labs/argocd-autopilot/releases/download/$VERSION/argocd-autopilot-darwin-amd64.gz | tar zx
+curl -L --output - https://github.com/argoproj-labs/argocd-autopilot/releases/download/$VERSION/argocd-autopilot-darwin-amd64.tar.gz | tar zx
 
 # move the binary to your $PATH
 mv ./argocd-autopilot-* /usr/local/bin/argocd-autopilot
@@ -42,7 +42,7 @@ argocd-autopilot version
 VERSION=$(curl --silent "https://api.github.com/repos/argoproj-labs/argocd-autopilot/releases/latest" | grep '"tag_name"' | sed -E 's/.*"([^"]+)".*/\1/')
 
 # download and extract the binary
-curl -L --output - https://github.com/argoproj-labs/argocd-autopilot/releases/download/$VERSION/argocd-autopilot-linux-amd64.gz | tar zx
+curl -L --output - https://github.com/argoproj-labs/argocd-autopilot/releases/download/$VERSION/argocd-autopilot-linux-amd64.tar.gz | tar zx
 
 # move the binary to your $PATH
 mv ./argocd-autopilot-* /usr/local/bin/argocd-autopilot

--- a/docs/Installation-Guide.md
+++ b/docs/Installation-Guide.md
@@ -8,7 +8,7 @@ To use the `argocd-autopilot` CLI you need to download the latest binary from th
 VERSION=$(curl --silent "https://api.github.com/repos/argoproj-labs/argocd-autopilot/releases/latest" | grep '"tag_name"' | sed -E 's/.*"([^"]+)".*/\1/')
 
 # download and extract the binary
-curl -L --output - https://github.com/argoproj-labs/argocd-autopilot/releases/download/$VERSION/argocd-autopilot-linux-amd64.gz | tar zx
+curl -L --output - https://github.com/argoproj-labs/argocd-autopilot/releases/download/$VERSION/argocd-autopilot-linux-amd64.tar.gz | tar zx
 
 # move the binary to your $PATH
 mv ./argocd-autopilot-* /usr/local/bin/argocd-autopilot
@@ -23,7 +23,7 @@ argocd-autopilot version
 VERSION=$(curl --silent "https://api.github.com/repos/argoproj-labs/argocd-autopilot/releases/latest" | grep '"tag_name"' | sed -E 's/.*"([^"]+)".*/\1/')
 
 # download and extract the binary
-curl -L --output - https://github.com/argoproj-labs/argocd-autopilot/releases/download/$VERSION/argocd-autopilot-darwin-amd64.gz | tar zx
+curl -L --output - https://github.com/argoproj-labs/argocd-autopilot/releases/download/$VERSION/argocd-autopilot-darwin-amd64.tar.gz | tar zx
 
 # move the binary to your $PATH
 mv ./argocd-autopilot-* /usr/local/bin/argocd-autopilot

--- a/docs/releases/release_notes.md
+++ b/docs/releases/release_notes.md
@@ -12,7 +12,7 @@ To use the `argocd-autopilot` CLI you need to download the latest binary from th
 VERSION=$(curl --silent "https://api.github.com/repos/argoproj-labs/argocd-autopilot/releases/latest" | grep '"tag_name"' | sed -E 's/.*"([^"]+)".*/\1/')
 
 # download and extract the binary
-curl -L --output - https://github.com/argoproj-labs/argocd-autopilot/releases/download/$VERSION/argocd-autopilot-linux-amd64.gz | tar zx
+curl -L --output - https://github.com/argoproj-labs/argocd-autopilot/releases/download/$VERSION/argocd-autopilot-linux-amd64.tar.gz | tar zx
 
 # move the binary to your $PATH
 mv ./argocd-autopilot-* /usr/local/bin/argocd-autopilot
@@ -27,7 +27,7 @@ argocd-autopilot version
 VERSION=$(curl --silent "https://api.github.com/repos/argoproj-labs/argocd-autopilot/releases/latest" | grep '"tag_name"' | sed -E 's/.*"([^"]+)".*/\1/')
 
 # download and extract the binary
-curl -L --output - https://github.com/argoproj-labs/argocd-autopilot/releases/download/$VERSION/argocd-autopilot-darwin-amd64.gz | tar zx
+curl -L --output - https://github.com/argoproj-labs/argocd-autopilot/releases/download/$VERSION/argocd-autopilot-darwin-amd64.tar.gz | tar zx
 
 # move the binary to your $PATH
 mv ./argocd-autopilot-* /usr/local/bin/argocd-autopilot

--- a/hack/build.sh
+++ b/hack/build.sh
@@ -14,5 +14,5 @@ ${PACKR_CMD} build -ldflags=" \
     -X 'github.com/argoproj/argocd-autopilot/pkg/store.buildDate=${BUILD_DATE}' \
     -X 'github.com/argoproj/argocd-autopilot/pkg/store.gitCommit=${GIT_COMMIT}' \
     -X 'github.com/argoproj/argocd-autopilot/pkg/store.installationManifestsURL=${INSTALLATION_MANIFESTS_URL}' \
-    -X 'github.com/argoproj/argocd-autopilot/pkg/store.InstallationManifestsNamespacedURL=${INSTALLATION_MANIFESTS_NAMESPACED_URL}'" \
+    -X 'github.com/argoproj/argocd-autopilot/pkg/store.installationManifestsNamespacedURL=${INSTALLATION_MANIFESTS_NAMESPACED_URL}'" \
     -v -o ${OUT_FILE} ${MAIN}

--- a/hack/release.sh
+++ b/hack/release.sh
@@ -21,7 +21,7 @@ if [[ "$?" == "0" ]]; then
     echo "on release branch: $GIT_BRANCH"
     echo ""
     echo "uploading files:"
-    ls -1a ./dist/*.gz ./dist/*.sha256
+    ls -1a ./dist/*.tar.gz ./dist/*.sha256
     echo ""
 
     FILE="./docs/releases/release_notes.md"
@@ -34,13 +34,13 @@ if [[ "$?" == "0" ]]; then
         echo ""
     fi
 
-    echo "running: gh release create --repo $GIT_REPO -t $GIT_BRANCH -F $FILE --target $GIT_BRANCH --prerelease=$PRERELEASE ./dist/*.gz ./dist/*.sha256"
+    echo "running: gh release create --repo $GIT_REPO -t $GIT_BRANCH -F $FILE --target $GIT_BRANCH --prerelease=$PRERELEASE ./dist/*.tar.gz ./dist/*.sha256"
     
     if [[ "$DRY_RUN" == "1" ]]; then
         exit 0
     fi
 
-    gh release create --repo $GIT_REPO -t $GIT_BRANCH -F $FILE --target $GIT_BRANCH --prerelease=$PRERELEASE $GIT_BRANCH ./dist/*.gz ./dist/*.sha256
+    gh release create --repo $GIT_REPO -t $GIT_BRANCH -F $FILE --target $GIT_BRANCH --prerelease=$PRERELEASE $GIT_BRANCH ./dist/*.tar.gz ./dist/*.sha256
 else 
     echo "not on release branch: $GIT_BRANCH"
     exit 1


### PR DESCRIPTION
Hi,

the build process of argocd-autopilot uses tar to creat the archive. So the extension of the archive should be names .tar.gz rather then gz.

![image](https://user-images.githubusercontent.com/38325136/119242386-8c972380-bb5d-11eb-890b-12a47b04a0c1.png)

This PR fixes the extension to tar.gz