### PR TITLE
Add opts.Host URL to gitlab provider

### DIFF
--- a/pkg/git/provider_gitlab.go
+++ b/pkg/git/provider_gitlab.go
@@ -29,7 +29,7 @@ type (
 )
 
 func newGitlab(opts *ProviderOptions) (Provider, error) {
-	c, err := gl.NewClient(opts.Auth.Password)
+	c, err := gl.NewClient(opts.Auth.Password, gl.WithBaseURL(opts.Host))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Added  opts.Host URL to gitlab provider to support private (self-hosted) gitlab instances.