### PR TITLE
Add Scoop support in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,21 +71,6 @@ mv ./argocd-autopilot-* /usr/local/bin/argocd-autopilot
 argocd-autopilot version
 ```
 
-### Mac (using curl):
-```bash
-# get the latest version or change to a specific version
-VERSION=$(curl --silent "https://api.github.com/repos/argoproj-labs/argocd-autopilot/releases/latest" | grep '"tag_name"' | sed -E 's/.*"([^"]+)".*/\1/')
-
-# download and extract the binary
-curl -L --output - https://github.com/argoproj-labs/argocd-autopilot/releases/download/$VERSION/argocd-autopilot-darwin-amd64.tar.gz | tar zx
-
-# move the binary to your $PATH
-mv ./argocd-autopilot-* /usr/local/bin/argocd-autopilot
-
-# check the installation
-argocd-autopilot version
-```
-
 ## Docker
 When using the Docker image, you have to provide the `.kube` and `.gitconfig` directories as mounts to the running container:
 ```

--- a/README.md
+++ b/README.md
@@ -29,6 +29,18 @@ brew install argocd-autopilot
 argocd-autopilot version
 ```
 
+### Using scoop:
+```bash
+# update
+scoop update
+
+# install
+scoop install argocd-autopilot
+
+# check the installation
+argocd-autopilot version
+```
+
 ### Linux and WSL (using curl):
 ```bash
 # get the latest version or change to a specific version
@@ -36,6 +48,21 @@ VERSION=$(curl --silent "https://api.github.com/repos/argoproj-labs/argocd-autop
 
 # download and extract the binary
 curl -L --output - https://github.com/argoproj-labs/argocd-autopilot/releases/download/$VERSION/argocd-autopilot-linux-amd64.tar.gz | tar zx
+
+# move the binary to your $PATH
+mv ./argocd-autopilot-* /usr/local/bin/argocd-autopilot
+
+# check the installation
+argocd-autopilot version
+```
+
+### Mac (using curl):
+```bash
+# get the latest version or change to a specific version
+VERSION=$(curl --silent "https://api.github.com/repos/argoproj-labs/argocd-autopilot/releases/latest" | grep '"tag_name"' | sed -E 's/.*"([^"]+)".*/\1/')
+
+# download and extract the binary
+curl -L --output - https://github.com/argoproj-labs/argocd-autopilot/releases/download/$VERSION/argocd-autopilot-darwin-amd64.tar.gz | tar zx
 
 # move the binary to your $PATH
 mv ./argocd-autopilot-* /usr/local/bin/argocd-autopilot

--- a/docs/Installation-Guide.md
+++ b/docs/Installation-Guide.md
@@ -11,6 +11,18 @@ brew install argocd-autopilot
 argocd-autopilot version
 ```
 
+### Using scoop:
+```bash
+# update
+scoop update
+
+# install
+scoop install argocd-autopilot
+
+# check the installation
+argocd-autopilot version
+```
+
 ### Linux and WSL (using curl):
 ```bash
 # get the latest version or change to a specific version

--- a/docs/releases/release_notes.md
+++ b/docs/releases/release_notes.md
@@ -17,6 +17,18 @@ brew install argocd-autopilot
 argocd-autopilot version
 ```
 
+### Using scoop:
+```bash
+# update
+scoop update
+
+# install
+scoop install argocd-autopilot
+
+# check the installation
+argocd-autopilot version
+```
+
 ### Linux and WSL (using curl):
 ```bash
 # download and extract the binary


### PR DESCRIPTION
Added argocd-autopilot to scoop https://github.com/ScoopInstaller/Main/blob/master/bucket/argocd-autopilot.json and updated docs.