### PR TITLE
Add Linux AUR support in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,13 @@ choco install argocd-autopilot
 argocd-autopilot version
 ```
 
+### Linux AUR:
+```bash
+yay -S argocd-autopilot-bin
+or
+sudo pacman -S argocd-autopilot-bin
+```
+
 ### Linux and WSL (using curl):
 ```bash
 # get the latest version or change to a specific version

--- a/README.md
+++ b/README.md
@@ -52,9 +52,13 @@ argocd-autopilot version
 
 ### Linux AUR:
 ```bash
+# install
 yay -S argocd-autopilot-bin
-or
+# or
 sudo pacman -S argocd-autopilot-bin
+
+# check the installation
+argocd-autopilot version
 ```
 
 ### Linux and WSL (using curl):


### PR DESCRIPTION
Added a PKGBUILD to the AUR repostiory https://aur.archlinux.org/packages/argocd-autopilot-bin for easy installation with arch package managers.