### PR TITLE
docs: fix edit url to use `main` branch

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,7 @@
 site_name: Argo-CD Autopilot
 site_url: https://argocd-autopilot.readthedocs.io
 repo_url: https://github.com/argoproj-labs/argocd-autopilot
+edit_uri: edit/main/docs/
 strict: true
 theme:
   name: material


### PR DESCRIPTION
Hello 🙂, this PR fixes a broken URL of the edit button on the documentation.

If you click the edit button on the documentation page, you will be redirected to a URL like this: https://github.com/argoproj-labs/argocd-autopilot/edit/master/docs/index.md. But we could not access the page since the branch name was renamed from `master` to `main` at some time.

To fix the issue, we need to explicitly specify the [`edit_uri` option](https://www.mkdocs.org/user-guide/configuration/#edit_uri) of the mkdocs, which uses the `master` branch by default.

I confirmed this change works on my local build by running `make serve-docs` command:

<img width="605" alt="Screen Shot 2022-05-07 at 20 49 15" src="https://user-images.githubusercontent.com/1425259/167253422-5dcaf6f4-ad21-43d2-aaee-a08a6e3b9f2f.png">
