### PR TITLE
feat: allow --provider for all git commands (and add GIT_PROVIDER env)

### DIFF
--- a/cmd/commands/app.go
+++ b/cmd/commands/app.go
@@ -88,10 +88,11 @@ func NewAppCreateCommand() *cobra.Command {
 
 		export GIT_TOKEN=<token>
 		export GIT_REPO=<repo_url>
+		export GIT_PROVIDER=<provider> # optional: autodetected by default
 
 # or with the flags:
 
-		--git-token <token> --repo <repo_url>
+		--git-token <token> --repo <repo_url> [--provider <provider>]
 
 # using the --type flag (kustomize|dir) is optional. If it is ommitted, <BIN> will clone
 # the --app repository, and infer the type automatically.
@@ -329,12 +330,13 @@ func NewAppListCommand() *cobra.Command {
 
 		export GIT_TOKEN=<token>
 		export GIT_REPO=<repo_url>
+		export GIT_PROVIDER=<provider> # optional: autodetected by default
 
 # or with the flags:
 
-		--git-token <token> --repo <repo_url>
+		--git-token <token> --repo <repo_url> [--provider <provider>]
 
-# Get list of installed applications in a specifc project
+# Get list of installed applications in a specific project
 
 	<BIN> app list <project_name>
 `),
@@ -419,10 +421,11 @@ func NewAppDeleteCommand() *cobra.Command {
 
 		export GIT_TOKEN=<token>
 		export GIT_REPO=<repo_url>
+		export GIT_PROVIDER=<provider> # optional: autodetected by default
 
 # or with the flags:
 
-		--git-token <token> --repo <repo_url>
+		--git-token <token> --repo <repo_url> [--provider <provider>]
 
 # Get list of installed applications in a specifc project
 

--- a/cmd/commands/project.go
+++ b/cmd/commands/project.go
@@ -98,10 +98,11 @@ func NewProjectCreateCommand() *cobra.Command {
 
 		export GIT_TOKEN=<token>
 		export GIT_REPO=<repo_url>
+		export GIT_PROVIDER=<provider> # optional: autodetected by default
 
 # or with the flags:
 
-		--git-token <token> --repo <repo_url>
+		--git-token <token> --repo <repo_url> [--provider <provider>]
 
 # Create a new project
 
@@ -373,10 +374,11 @@ func NewProjectListCommand() *cobra.Command {
 
 		export GIT_TOKEN=<token>
 		export GIT_REPO=<repo_url>
+		export GIT_PROVIDER=<provider> # optional: autodetected by default
 
 # or with the flags:
 
-		--git-token <token> --repo <repo_url>
+		--git-token <token> --repo <repo_url> [--provider <provider>]"
 
 # Lists projects
 
@@ -449,10 +451,11 @@ func NewProjectDeleteCommand() *cobra.Command {
 	
 		export GIT_TOKEN=<token>
 		export GIT_REPO=<repo_url>
+		export GIT_PROVIDER=<provider> # optional: autodetected by default
 
 # or with the flags:
 	
-		--token <token> --repo <repo_url>
+		--token <token> --repo <repo_url> [--provider <provider>]
 		
 # Delete a project
 	

--- a/pkg/git/repository.go
+++ b/pkg/git/repository.go
@@ -61,11 +61,11 @@ type (
 		CreateIfNotExist bool
 		CloneForWrite    bool
 		UpsertBranch     bool
-	
-		url              string
-		revision         string
-		path             string
-		provider         Provider
+
+		url      string
+		revision string
+		path     string
+		provider Provider
 	}
 
 	PushOptions struct {
@@ -152,15 +152,14 @@ func AddFlags(cmd *cobra.Command, opts *AddFlagsOptions) *CloneOptions {
 	util.Die(viper.BindEnv(opts.Prefix+"git-token", envPrefix+"GIT_TOKEN"))
 	util.Die(viper.BindEnv(opts.Prefix+"git-user", envPrefix+"GIT_USER"))
 	util.Die(viper.BindEnv(opts.Prefix+"repo", envPrefix+"GIT_REPO"))
+	util.Die(viper.BindEnv(opts.Prefix+"provider", envPrefix+"GIT_PROVIDER"))
 
 	if opts.Prefix == "" {
 		cmd.Flag("git-token").Shorthand = "t"
 		cmd.Flag("git-user").Shorthand = "u"
 	}
 
-	if opts.CreateIfNotExist {
-		cmd.PersistentFlags().StringVar(&co.Provider, opts.Prefix+"provider", "", fmt.Sprintf("The git provider, one of: %v", strings.Join(Providers(), "|")))
-	}
+	cmd.PersistentFlags().StringVar(&co.Provider, opts.Prefix+"provider", "", fmt.Sprintf("The git provider, one of: %v", strings.Join(Providers(), "|")))
 
 	if opts.CloneForWrite {
 		cmd.PersistentFlags().BoolVarP(&co.UpsertBranch, opts.Prefix+"upsert-branch", "b", false, "If true will try to checkout the specified branch and create it if it doesn't exist")


### PR DESCRIPTION
added `--provider` flag to all git repository based commands as those will fail otherwise when autodetection doesn't work (e.g. internal git repository)