### PR TITLE
Fix gitea repo bootstrap failure

### DIFF
--- a/pkg/git/provider_gitea.go
+++ b/pkg/git/provider_gitea.go
@@ -5,6 +5,8 @@ import (
 	"fmt"
 	"net/http"
 
+	"github.com/argoproj-labs/argocd-autopilot/pkg/util"
+
 	gt "code.gitea.io/sdk/gitea"
 )
 
@@ -24,7 +26,8 @@ type (
 )
 
 func newGitea(opts *ProviderOptions) (Provider, error) {
-	c, err := gt.NewClient(opts.RepoURL, gt.SetToken(opts.Auth.Password))
+	host, _, _, _, _, _, _ := util.ParseGitUrl(opts.RepoURL)
+	c, err := gt.NewClient(host, gt.SetToken(opts.Auth.Password))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Fix issue #278

The gitea client requires the gitea host URL for the repo but the provider provides a full repo URL. 
So repo bootstrap with gitea provider cannot work. 