### PR TITLE
v0.4.20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog:
 
+# v0.4.20
+- [fix] Fix ArgoCD 3.0.0+ compatibility by replacing legacy repo credentials with proper repo-creds secret [#674](https://github.com/argoproj-labs/argocd-autopilot/pull/674)
+- [fix] repo bootstrap fails when repository does not exist in the git provider [#675](https://github.com/argoproj-labs/argocd-autopilot/issues/675)
+
 # v0.4.19
 - [chore] update github.com/argoproj/argo-cd/v2 v2.13.1 to v2.13.4 [#635](https://github.com/argoproj-labs/argocd-autopilot/pull/635)
 - [chore] update github.com/go-git/go-billy/v5 v5.5.0 to v5.6.2 [#635](https://github.com/argoproj-labs/argocd-autopilot/pull/635)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,15 @@
 # v0.4.20
 - [fix] Fix ArgoCD 3.0.0+ compatibility by replacing legacy repo credentials with proper repo-creds secret [#674](https://github.com/argoproj-labs/argocd-autopilot/pull/674)
 - [fix] repo bootstrap fails when repository does not exist in the git provider [#675](https://github.com/argoproj-labs/argocd-autopilot/issues/675)
+- [chore] upgraded github.com/argoproj/argo-cd/v2 v2.13.4 => github.com/argoproj/argo-cd/v3 v3.1.5 [#678](https://github.com/argoproj-labs/argocd-autopilot/pull/678)
+- [chore] upgraded github.com/spf13/pflag v1.0.5 => v1.0.10 [#678](https://github.com/argoproj-labs/argocd-autopilot/pull/678)
+- [chore] upgraded github.com/briandowns/spinner v1.23.1 => v1.23.2 [#678](https://github.com/argoproj-labs/argocd-autopilot/pull/678)
+- [chore] upgraded github.com/go-jose/go-jose/v4 v4.0.4 => v4.1.2 [#678](https://github.com/argoproj-labs/argocd-autopilot/pull/678)
+- [chore] upgraded github.com/redis/go-redis/v9 v9.6.1 => v9.14.0 [#678](https://github.com/argoproj-labs/argocd-autopilot/pull/678)
+- [chore] upgraded code.gitea.io/sdk/gitea v0.19.0 => v0.22.0 [#678](https://github.com/argoproj-labs/argocd-autopilot/pull/678)
+- [chore] upgraded gitlab.com/gitlab-org/api/client-go v0.121.0 => v0.143.3 [#678](https://github.com/argoproj-labs/argocd-autopilot/pull/678)
+- [chore] update to golang 1.25.1 [#678](https://github.com/argoproj-labs/argocd-autopilot/pull/678)
+- [chore] updated golangci-lint to 2.4.0 [#678](https://github.com/argoproj-labs/argocd-autopilot/pull/678)
 
 # v0.4.19
 - [chore] update github.com/argoproj/argo-cd/v2 v2.13.1 to v2.13.4 [#635](https://github.com/argoproj-labs/argocd-autopilot/pull/635)

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-VERSION=v0.4.19
+VERSION=v0.4.20
 OUT_DIR=dist
 
 CLI_NAME?=argocd-autopilot

--- a/docs/releases/release_notes.md
+++ b/docs/releases/release_notes.md
@@ -1,16 +1,11 @@
 ### Changes
 
-- [chore] update github.com/argoproj/argo-cd/v2 v2.13.1 to v2.13.4 [#635](https://github.com/argoproj-labs/argocd-autopilot/pull/635)
-- [chore] update github.com/go-git/go-billy/v5 v5.5.0 to v5.6.2 [#635](https://github.com/argoproj-labs/argocd-autopilot/pull/635)
-- [chore] update github.com/go-git/go-git/v5 v5.12.0 to v5.13.2 [#635](https://github.com/argoproj-labs/argocd-autopilot/pull/635)
-- [chore] replace github.com/xanzy/go-gitlab v0.91.1 with gitlab.com/gitlab-org/api/client-go v0.121.0 [#635](https://github.com/argoproj-labs/argocd-autopilot/pull/635)
-- [chore] update sigs.k8s.io/kustomize/api v0.17.2 to v0.19.0 [#635](https://github.com/argoproj-labs/argocd-autopilot/pull/635)
-- [chore] update sigs.k8s.io/kustomize/kyaml v0.17.1 to v0.19.0 [#635](https://github.com/argoproj-labs/argocd-autopilot/pull/635)
-- [chore] update golang to 1.24 [#634](https://github.com/argoproj-labs/argocd-autopilot/pull/634)
-- [feat] add cluster-only uninstall option and resource deletion handling [#634](https://github.com/argoproj-labs/argocd-autopilot/pull/634)
+- [fix] Fix ArgoCD 3.0.0+ compatibility by replacing legacy repo credentials with proper repo-creds secret [#674](https://github.com/argoproj-labs/argocd-autopilot/pull/674)
+- [fix] repo bootstrap fails when repository does not exist in the git provider [#675](https://github.com/argoproj-labs/argocd-autopilot/issues/675)
 
 ### Contributors:
 
+- Aron Reis ([@aronreisx](https://github.com/aronreisx))
 - Noam Gal ([@ATGardner](https://github.com/ATGardner))
 
 ## Installation:
@@ -54,7 +49,7 @@ argocd-autopilot version
 
 ```bash
 # download and extract the binary
-curl -L --output - https://github.com/argoproj-labs/argocd-autopilot/releases/download/v0.4.19/argocd-autopilot-linux-amd64.tar.gz | tar zx
+curl -L --output - https://github.com/argoproj-labs/argocd-autopilot/releases/download/v0.4.20/argocd-autopilot-linux-amd64.tar.gz | tar zx
 
 # move the binary to your $PATH
 mv ./argocd-autopilot-* /usr/local/bin/argocd-autopilot
@@ -67,7 +62,7 @@ argocd-autopilot version
 
 ```bash
 # download and extract the binary
-curl -L --output - https://github.com/argoproj-labs/argocd-autopilot/releases/download/v0.4.19/argocd-autopilot-darwin-amd64.tar.gz | tar zx
+curl -L --output - https://github.com/argoproj-labs/argocd-autopilot/releases/download/v0.4.20/argocd-autopilot-darwin-amd64.tar.gz | tar zx
 
 # move the binary to your $PATH
 mv ./argocd-autopilot-* /usr/local/bin/argocd-autopilot

--- a/docs/releases/release_notes.md
+++ b/docs/releases/release_notes.md
@@ -2,6 +2,15 @@
 
 - [fix] Fix ArgoCD 3.0.0+ compatibility by replacing legacy repo credentials with proper repo-creds secret [#674](https://github.com/argoproj-labs/argocd-autopilot/pull/674)
 - [fix] repo bootstrap fails when repository does not exist in the git provider [#675](https://github.com/argoproj-labs/argocd-autopilot/issues/675)
+- [chore] upgraded github.com/argoproj/argo-cd/v2 v2.13.4 => github.com/argoproj/argo-cd/v3 v3.1.5 [#678](https://github.com/argoproj-labs/argocd-autopilot/pull/678)
+- [chore] upgraded github.com/spf13/pflag v1.0.5 => v1.0.10 [#678](https://github.com/argoproj-labs/argocd-autopilot/pull/678)
+- [chore] upgraded github.com/briandowns/spinner v1.23.1 => v1.23.2 [#678](https://github.com/argoproj-labs/argocd-autopilot/pull/678)
+- [chore] upgraded github.com/go-jose/go-jose/v4 v4.0.4 => v4.1.2 [#678](https://github.com/argoproj-labs/argocd-autopilot/pull/678)
+- [chore] upgraded github.com/redis/go-redis/v9 v9.6.1 => v9.14.0 [#678](https://github.com/argoproj-labs/argocd-autopilot/pull/678)
+- [chore] upgraded code.gitea.io/sdk/gitea v0.19.0 => v0.22.0 [#678](https://github.com/argoproj-labs/argocd-autopilot/pull/678)
+- [chore] upgraded gitlab.com/gitlab-org/api/client-go v0.121.0 => v0.143.3 [#678](https://github.com/argoproj-labs/argocd-autopilot/pull/678)
+- [chore] update to golang 1.25.1 [#678](https://github.com/argoproj-labs/argocd-autopilot/pull/678)
+- [chore] updated golangci-lint to 2.4.0 [#678](https://github.com/argoproj-labs/argocd-autopilot/pull/678)
 
 ### Contributors:
 


### PR DESCRIPTION
- Fix ArgoCD 3.0.0+ compatibility by replacing legacy repo credentials
  with proper repo-creds secret [#674].
- Resolve issue where repo bootstrap fails when repository does not
  exist in the git provider [#675].

Signed-off-by: Noam Gal <noam.gal@octopus.com>